### PR TITLE
Blazor Server example in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ public void SendMessage()
 
 In the destination component all you can do is calling the subscribe method to subscribe for a target of messaging 
 
+Blazor WebAssembly
+
 ``` C#
 public void SubscribeToMessage()
 {
@@ -69,6 +71,24 @@ public void SubscribeToMessage()
 		// If the value is updating the component make sure to call 
 		string greeting = $"Welcome {value}";
 		StateHasChanged(); // To update the state of the component 
+	});
+}
+```
+
+Blazor Server
+
+``` C#
+public void SubscribeToMessage()
+{
+	MessagingCenter.Subscribe<Component1, string>(this, "greeting_message", async (sender, value) => 
+	{
+		// Do actions against the value 
+		// If the value is updating the component make sure to call 
+		// Use InvokeAsync() to switch execution to the Dispatcher when triggering rendering or component state
+		await InvokeAsync(() => {
+			string greeting = $"Welcome {value}";
+			StateHasChanged(); // To update the state of the component 
+		});
 	});
 }
 ```


### PR DESCRIPTION
Blazor WebAssembly is single threaded and executes everything on the UI thread. BlazorUtilitiesSample work correctly.

Blazor Server is multi threaded and not guaranteed that everything will run in the user interface thread.
A small change is required when using Blazor Server:

``` C#
MessagingCenter.Subscribe<Component1, string>(this, "greeting_message", async (sender, value) =>
{
    await InvokeAsync(() => {
        string greeting = $"Welcome {value}";
        StateHasChanged(); // To update the state of the component 
    });
});
```

Otherwise, the following exception occurs: 
System.InvalidOperationException: 'The current thread is not associated with the Dispatcher. Use InvokeAsync() to switch execution to the Dispatcher when triggering rendering or component state.'
